### PR TITLE
fix: forward compatibility for nuxt v3.16

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -104,7 +104,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.options.build.transpile.push(runtimeDir)
     nuxt.options.vite.define['process.env.DEBUG'] =
-      nuxt.options.debug.toString()
+      Boolean(nuxt.options.debug).toString()
 
     for (const fname of ['default']) {
       const path = resolve(runtimeDir, nuxt.options.dir.layouts, `${fname}.vue`)


### PR DESCRIPTION
with the merge of https://github.com/nuxt/nuxt/pull/30578, `nuxt.options.debug` may be an _object_ and so the current behaviour will throw an error.

This change should be backwards/forwards compatible.